### PR TITLE
Fix labels set to '\' and display labels

### DIFF
--- a/public/js/forum.js
+++ b/public/js/forum.js
@@ -207,6 +207,10 @@ $(document).ready(function() {
                         </div>'
                     )
                 );
+                $("#forumLabels").html(
+                    res.labels.length ? 
+                        '<h2> Labels </h2><p>' + res.labels + '</p>' : ''
+                );
                 for (cloth of res.clothing) {
                     $("#forumClothing").append(
                         '<div class="col-sm-6 col-md-4">\

--- a/routes/forums.js
+++ b/routes/forums.js
@@ -194,6 +194,9 @@ router.put('/:forum_id', (req, res) => {
     if (labels) {
         labels = labels.split(",").map(label => label.trim());
     }
+    else {
+        labels = [];
+    }
 
     forumsData.updateForum(forumId, userId, title, content, labels)
         .then((forumData) => {

--- a/views/forums/single.handlebars
+++ b/views/forums/single.handlebars
@@ -26,10 +26,13 @@
             </li>
         </ul>
 
-        {{#if forum.label}}
+        <div id="forumLabels">
+        {{#if forum.labels}}
             <h2> Labels </h2>
-            <p> {{ forum.label }} </p>
+            <p> {{ forum.labels }} </p>
         {{/if}}
+        </div>
+
         <h2> Clothing </h2>
         <div class="row" id="forumClothing">
         {{#each forum.clothing }}
@@ -101,7 +104,11 @@
                     <div class="alert alert-info" role="alert">
                         <p>Seperate labels by commas</p>
                     </div>
-                    <input id="newForumLabels" type="text" class="form-control" name="labels" placeholder="label1,label2,label3" value={{forum.labels}} />
+                    {{#if forum.labels.length}}
+                        <input id="newForumLabels" type="text" class="form-control" name="labels" placeholder="label1,label2,label3" value={{forum.labels}} />
+                    {{else}}
+                        <input id="newForumLabels" type="text" class="form-control" name="labels" placeholder="label1,label2,label3" value=""/>
+                    {{/if}}
                 </div>
             </div>
 


### PR DESCRIPTION
Labels now displays on forum page: 
![image](https://user-images.githubusercontent.com/4238686/29752972-d82b61dc-8b35-11e7-9e81-fd9b282b57e1.png)
![image](https://user-images.githubusercontent.com/4238686/29752975-f3fe478a-8b35-11e7-86fd-5ebd9317d8d9.png)

No \\ appears when forums are empty, and unchanged empty forums remain empty.
![image](https://user-images.githubusercontent.com/4238686/29752983-102d3d4e-8b36-11e7-8461-0414d5cb9e0e.png)
